### PR TITLE
Remove NODE_AUTH_TOKEN from npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,5 +35,3 @@ jobs:
       - run: npm run build
       - run: npm run verify:pack
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anikitenko/fdo-sdk",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anikitenko/fdo-sdk",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "ISC",
       "dependencies": {
         "@expo/sudo-prompt": "github:expo/sudo-prompt",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/anikitenko/fdo-sdk.git"
   },
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "SDK for FlexDevOPs (FDO) application modules",
   "keywords": [
     "fdo",


### PR DESCRIPTION
Removed NODE_AUTH_TOKEN environment variable from npm publish step.